### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ rexlex
 
 [![Build Status](https://travis-ci.org/twneale/rexlex.svg?branch=master)](https://travis-ci.org/twneale/rexlex)
 [![Coverage Status](https://coveralls.io/repos/twneale/rexlex/badge.png?branch=master)](https://coveralls.io/r/twneale/rexlex?branch=master)
-[![Latest Version](https://pypip.in/version/rexlex/badge.png)](https://pypi.python.org/pypi/rexlex/)
-[![Download Format](https://pypip.in/format/rexlex/badge.png)](https://pypi.python.org/pypi/rexlex/)
+[![Latest Version](https://img.shields.io/pypi/v/rexlex.svg)](https://pypi.python.org/pypi/rexlex/)
+[![Download Format](https://img.shields.io/pypi/format/rexlex.svg)](https://pypi.python.org/pypi/rexlex/)
 
 This package is a basic regular expression lexer implementation inspired by the [Pyments](http://pygments.org/) [RegexLexer](https://bitbucket.org/birkenfeld/pygments-main/src/b839f47dbb3a10830db7dc3114f0ad4f470bcfa5/pygments/lexer.py?at=default),
 only with more verbose debug/trace output.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20rexlex))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `rexlex`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.